### PR TITLE
Run MadQP fully on the GPU

### DIFF
--- a/scripts/CUDA/cuda_wrapper.jl
+++ b/scripts/CUDA/cuda_wrapper.jl
@@ -3,6 +3,7 @@ using CUDA
 using CUDA.CUSPARSE
 using MadNLPGPU
 using KernelAbstractions
+using SparseArrays
 
 @kernel function _transfer_to_map!(dest, to_map, src)
     k = @index(Global, Linear)

--- a/scripts/CUDA/cuda_wrapper.jl
+++ b/scripts/CUDA/cuda_wrapper.jl
@@ -1,0 +1,33 @@
+
+using CUDA
+using CUDA.CUSPARSE
+using MadNLPGPU
+using KernelAbstractions
+
+@kernel function _transfer_to_map!(dest, to_map, src)
+    k = @index(Global, Linear)
+    @inbounds begin
+        # TODO: do we need Atomix?
+        dest[to_map[k]] += src[k]
+    end
+end
+
+function MadNLP.transfer!(
+    dest::CUSPARSE.CuSparseMatrixCSC{Tv},
+    src::MadNLP.SparseMatrixCOO{Tv},
+    map::CuVector{Int},
+) where {Tv}
+    fill!(nonzeros(dest), zero(Tv))
+    if length(map) > 0
+        _transfer_to_map!(CUDABackend())(nonzeros(dest), map, src.V; ndrange=length(map))
+        KernelAbstractions.synchronize(CUDABackend())
+    end
+    return
+end
+
+function MadNLP.compress_hessian!(
+    kkt::MadNLP.SparseKKTSystem{T,VT,MT},
+) where {T,VT,MT<:CUSPARSE.CuSparseMatrixCSC{T,Int32}}
+    MadNLP.transfer!(kkt.hess_com, kkt.hess_raw, kkt.hess_csc_map)
+end
+

--- a/scripts/CUDA/qp_gpu.jl
+++ b/scripts/CUDA/qp_gpu.jl
@@ -1,0 +1,126 @@
+
+using LinearAlgebra
+using NLPModels
+using QuadraticModels
+using CUDA
+using SparseArrays
+using CUDA.CUSPARSE
+using KernelAbstractions
+import QuadraticModels: SparseMatrixCOO
+
+@kernel function _fill_sparse_structure!(rows, cols, Ap, Aj, Ax)
+    i = @index(Global, Linear)
+    for c in Ap[i]:Ap[i+1]-1
+        rows[c] = i
+        cols[c] = Aj[c]
+    end
+end
+
+function fill_structure!(A::CUSPARSE.CuSparseMatrixCSR, rows, cols)
+    @assert length(cols) == length(rows)
+    if length(cols) > 0
+        _fill_sparse_structure!(CUDABackend())(
+            rows, cols,
+            A.rowPtr, A.colVal, A.nzVal; ndrange=size(A, 1),
+        )
+    end
+end
+
+function NLPModels.hess_structure!(
+    qp::QuadraticModel{T, S, M1},
+    rows::AbstractVector{<:Integer},
+    cols::AbstractVector{<:Integer},
+) where {T, S, M1 <: CUSPARSE.CuSparseMatrixCSR}
+    fill_structure!(qp.data.H, rows, cols)
+    return rows, cols
+end
+
+function NLPModels.hess_coord!(
+    qp::QuadraticModel{T, S, M1},
+    x::AbstractVector{T},
+    vals::AbstractVector{T};
+    obj_weight::Real = one(eltype(x)),
+) where {T, S, M1 <: CUSPARSE.CuSparseMatrixCSR}
+    NLPModels.increment!(qp, :neval_hess)
+    vals .= obj_weight .* qp.data.H.nzVal
+    return vals
+end
+
+function NLPModels.jac_lin_coord!(
+    qp::QuadraticModel{T, S, M1, M2},
+    x::AbstractVector,
+    vals::AbstractVector,
+) where {T, S, M1, M2 <: CUSPARSE.CuSparseMatrixCSR}
+    @lencheck qp.meta.nvar x
+    @lencheck qp.meta.lin_nnzj vals
+    NLPModels.increment!(qp, :neval_jac_lin)
+    vals .= qp.data.A.nzVal
+    return vals
+end
+
+function NLPModels.jac_lin_structure!(
+    qp::QuadraticModel{T, S, M1, M2},
+    rows::AbstractVector{<:Integer},
+    cols::AbstractVector{<:Integer},
+) where {T, S, M1, M2 <: CUSPARSE.CuSparseMatrixCSR}
+    @lencheck qp.meta.lin_nnzj rows cols
+    fill_structure!(qp.data.A, rows, cols)
+    return rows, cols
+end
+
+function NLPModels.jac_structure!(
+    qp::QuadraticModel{T, S, M1, M2},
+    rows::AbstractVector{<:Integer},
+    cols::AbstractVector{<:Integer},
+) where {T, S, M1, M2 <: CUSPARSE.CuSparseMatrixCSR}
+    @lencheck qp.meta.lin_nnzj rows cols
+    fill_structure!(qp.data.A, rows, cols)
+    return rows, cols
+end
+
+#=
+    CuSparseMatrixCOO
+=#
+
+function CuSparseMatrixCOO(A::SparseMatrixCOO{Tv, Ti}) where {Tv, Ti}
+    return CUSPARSE.CuSparseMatrixCOO{Tv, Ti}(
+        CuVector(A.rows),
+        CuVector(A.cols),
+        CuVector(A.vals),
+        size(A),
+        nnz(A),
+    )
+end
+
+#=
+    CuSparseMatrixCSR
+=#
+
+function CuSparseMatrixCSR(A::SparseMatrixCOO{Tv, Ti}) where {Tv, Ti}
+    m, n = size(A)
+    Ap, Ai, Ax = MadQP.coo_to_csr(m, n, A.rows, A.cols, A.vals)
+    return CUSPARSE.CuSparseMatrixCSR{Tv, Ti}(
+        CuVector(Ap),
+        CuVector(Ai),
+        CuVector(Ax),
+        size(A),
+    )
+end
+
+#=
+    Pass QuadraticModel to the GPU
+=#
+
+function transfer_to_gpu(qp::QuadraticModel{T, VT}) where {T, VT}
+    return QuadraticModel(
+        CuVector{T}(qp.data.c),
+        CuSparseMatrixCSR(qp.data.H);
+        A=CuSparseMatrixCSR(qp.data.A),
+        lcon=CuVector{T}(qp.meta.lcon),
+        ucon=CuVector{T}(qp.meta.ucon),
+        lvar=CuVector{T}(qp.meta.lvar),
+        uvar=CuVector{T}(qp.meta.uvar),
+        c0=qp.data.c0,
+        x0=CuVector{T}(qp.meta.x0),
+    )
+end

--- a/scripts/CUDA/test_gpu.jl
+++ b/scripts/CUDA/test_gpu.jl
@@ -1,0 +1,37 @@
+
+using LinearAlgebra
+using JuMP
+using MadQP
+using MadNLP
+
+using ExaModels
+
+include("cuda_wrapper.jl")
+
+# Build QP using JuMP
+A = rand(2, 10)
+model = Model()
+@variable(model,  0 <= x[1:10])
+# @constraint(model, A * x .== 0.0)
+@constraint(model, sum(x) == 1.0)
+@objective(model, Min, -ones(10)' * x)
+
+# Pass it to the GPU using ExaModels
+qp = ExaModels.ExaModel(model; backend=CUDABackend())
+
+solver = MadQP.MPCSolver(
+    qp;
+    max_iter=100,
+    linear_solver=MadNLPGPU.CUDSSSolver,
+    cholmod_algorithm=MadNLP.LDL,
+    print_level=MadNLP.INFO,
+    scaling=true,
+    tol=1e-8,
+    max_ncorr=3,
+    step_rule=MadQP.AdaptiveStep(0.99),
+    regularization=MadQP.FixedRegularization(1e-8, -1e-9),
+    rethrow_error=true,
+)
+
+MadQP.solve!(solver)
+

--- a/scripts/common.jl
+++ b/scripts/common.jl
@@ -1,0 +1,26 @@
+
+using QuadraticModels
+using NLPModels
+using QPSReader
+
+function NLPModels.cons!(qp::QuadraticModel{T}, x::AbstractVector{T}, c::AbstractVector{T}) where T
+    return NLPModels.cons_lin!(qp, x, c)
+end
+
+function import_mps(filename)
+    ext = match(r"(.*)\.(.*)", filename).captures[2]
+    data = if ext ∈ ("mps", "sif", "SIF")
+        readqps(filename)
+    elseif ext == "gz"
+        GZip.open(filename, "r") do gz
+            readqps(gz)
+        end
+    elseif ext == "bz2"
+        open(filename, "r") do io
+            stream = Bzip2DecompressorStream(io)
+            readqps(stream)
+        end
+    end
+    return data
+end
+

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -40,7 +40,7 @@ function set_predictive_rhs!(solver::MadNLP.AbstractMadNLPSolver, kkt::MadNLP.Ab
     return
 end
 
-function set_correction_rhs!(solver::MadNLP.AbstractMadNLPSolver, kkt::MadNLP.AbstractKKTSystem, mu::Float64, correction_lb::Vector{Float64}, correction_ub::Vector{Float64}, ind_lb, ind_ub)
+function set_correction_rhs!(solver::MadNLP.AbstractMadNLPSolver, kkt::MadNLP.AbstractKKTSystem, mu::Float64, correction_lb::AbstractVector{Float64}, correction_ub::AbstractVector{Float64}, ind_lb, ind_ub)
     px = MadNLP.primal(solver.p)
     py = MadNLP.dual(solver.p)
     pzl = MadNLP.dual_lb(solver.p)
@@ -422,7 +422,14 @@ end
 
 # Dual objective
 function dual_objective(solver::MPCSolver)
-    return -dot(solver.y, solver.rhs) + dot(solver.zl_r, solver.xl_r) - dot(solver.zu_r, solver.xu_r)
+    dobj = -dot(solver.y, solver.rhs)
+    if length(solver.xl_r) > 0
+        dobj += dot(solver.zl_r, solver.xl_r)
+    end
+    if length(solver.xu_r) > 0
+        dobj -= dot(solver.zu_r, solver.xu_r)
+    end
+    return dobj
 end
 
 function get_optimality_gap(solver::MPCSolver, ::LinearProgram)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -84,10 +84,10 @@ function init_starting_point!(solver::MadNLP.AbstractMadNLPSolver)
 
     μ = 0.0
     if length(zl) > 0
-        μ += dot(xl .- lb, zl)
+        μ += dot(xl, zl) - dot(lb, zl)
     end
     if length(zu) > 0
-        μ += dot(ub .- xu, zu)
+        μ += dot(ub, zl) - dot(xu, zl)
     end
 
     delta_x2 = μ / (2 * (sum(zl) + sum(zu)))

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -82,7 +82,13 @@ function init_starting_point!(solver::MadNLP.AbstractMadNLPSolver)
     zl .+= 1.0 + delta_s
     zu .+= 1.0 + delta_s
 
-    μ = dot(xl .- lb, zl) + dot(ub .- xu, zu)
+    μ = 0.0
+    if length(zl) > 0
+        μ += dot(xl .- lb, zl)
+    end
+    if length(zu) > 0
+        μ += dot(ub .- xu, zu)
+    end
 
     delta_x2 = μ / (2 * (sum(zl) + sum(zu)))
     delta_s2 = μ / (2 * (sum(xl .- lb) + sum(ub .- xu)))
@@ -96,7 +102,7 @@ function init_starting_point!(solver::MadNLP.AbstractMadNLPSolver)
     kappa = solver.opt.bound_fac
     map!(
         (l_, u_, x_) -> begin
-            res = if x_ < l_
+            out = if x_ < l_
                 pl = min(kappa * max(1.0, l_), kappa * (u_ - l_))
                 l_ + pl
             elseif u_ < x_
@@ -105,7 +111,7 @@ function init_starting_point!(solver::MadNLP.AbstractMadNLPSolver)
             else
                 x_
             end
-            res
+            out
         end,
         x,
         l, u, x,

--- a/src/structure.jl
+++ b/src/structure.jl
@@ -141,8 +141,8 @@ function MPCSolver(nlp::NLPModels.AbstractNLPModel{T,VT}; kwargs...) where {T, V
     _w2 = MadNLP.UnreducedKKTVector(VT, n, m, nlb, nub, ind_lb, ind_ub)
 
     # Buffers
-    correction_lb = zeros(nlb)
-    correction_ub = zeros(nub)
+    correction_lb = VT(undef, nlb)
+    correction_ub = VT(undef, nub)
     jacl = VT(undef,n)
     c_trial = VT(undef, m)
     y = VT(undef, m)


### PR DESCRIPTION
Add the missing kernels to run MadQP fully on the GPU. The script `scripts/CUDA/test_gpu.jl` works on my computer, using ExaModels to load the QP on the GPU and cuDSS to solve the KKT system. 

I would prefer to keep the GPU implementation in the folder `scripts/CUDA` for now, before implementing a proper extension MadQPCUDA. 

We should now focus on porting the QP in `QuadraticModels` on the GPU. 
