### PR TITLE
Fix complementarity residual in stopping criterion

### DIFF
--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -432,13 +432,7 @@ function dual_objective(solver::MPCSolver)
     return dobj
 end
 
-function get_optimality_gap(solver::MPCSolver, ::LinearProgram)
-    primal_obj = solver.obj_val
-    dual_obj = dual_objective(solver)
-    return (primal_obj - dual_obj) / max(1.0, abs(dual_obj))
-end
-
-function get_optimality_gap(solver::MPCSolver, ::QuadraticProgram)
+function get_optimality_gap(solver::MPCSolver)
     return MadNLP.get_inf_compl(
         solver.x_lr,
         solver.xl_r,
@@ -450,3 +444,4 @@ function get_optimality_gap(solver::MPCSolver, ::QuadraticProgram)
         1.0,
     )
 end
+

--- a/src/linear_solver.jl
+++ b/src/linear_solver.jl
@@ -38,7 +38,7 @@ function solve_system!(
         solver.logger,
         @sprintf("Residual after linear solve: %6.2e", residual_ratio),
     )
-    if opt.check_residual && (residual_ratio > opt.tol_linear_solve)
+    if isnan(residual_ratio) || (opt.check_residual && (residual_ratio > opt.tol_linear_solve))
         throw(MadNLP.SolveException)
     end
     return d

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -269,7 +269,8 @@ function mpc!(solver::MadNLP.AbstractMadNLPSolver)
             solver.jacl,
             1.0,
         ) / max(1.0, solver.norm_c)
-        solver.inf_compl = get_optimality_gap(solver, solver.class)
+        solver.inf_compl = get_optimality_gap(solver) / max(1.0, solver.norm_c)
+
         MadNLP.print_iter(solver)
 
         #####


### PR DESCRIPTION
- dual objective is broken, fallback to computation of complementarity residual implemented in MadNLP
- fix linear solves and returns an error if a `NaN` is detected