### PR TITLE
Use juilaup instead

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/install-juliaup@2
+      - uses: julia-actions/install-juliaup@v2
         with:
           channel: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-buildpkg@latest


### PR DESCRIPTION
`setup-julia` has been causing issues when two runners are fighting over `/opt/hostedtoolcache/julia/1.5.3/x64/bin`. This PR uses `setup-juliaup` instead