### PR TITLE
Generate getters for MadNLP 0.9.2 compat

### DIFF
--- a/src/structure.jl
+++ b/src/structure.jl
@@ -76,6 +76,24 @@ mutable struct MPCSolver{
     status::MadNLP.Status
 end
 
+for (k, attribute) in enumerate(fieldnames(MPCSolver))
+    fname = "get_$(attribute)"
+    sf = Symbol(fname)
+    if isdefined(MadNLP, sf)
+        @eval begin
+            @inline function MadNLP.$(sf)(solver::MPCSolver)
+                return getfield(solver, $k)
+            end
+        end
+    else
+        @eval begin
+            @inline function $(sf)(solver::MPCSolver)
+                return getfield(solver, $k)
+            end
+        end
+    end
+end
+
 function MPCSolver(nlp::NLPModels.AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
     options = load_options(nlp; kwargs...)
 
@@ -185,4 +203,3 @@ function MadNLP.print_iter(solver::MPCSolver; options...)
         solver.alpha_d,solver.alpha_p))
     return
 end
-


### PR DESCRIPTION
@frapac @apozharski https://github.com/MadNLP/MadNLP.jl/pull/497

Since MadIPM relies on MadNLP "internals" like `eval_f_wrapper` etc, it is a breaking change