### PR TITLE
Fix timing in MadIPM

### DIFF
--- a/src/batch/madipm/solver.jl
+++ b/src/batch/madipm/solver.jl
@@ -247,8 +247,6 @@ function initialize_solver_state!(batch_solver::AbstractBatchMPCSolver{T}) where
     fill!(ws.dual_obj, zero(T))
     fill!(ws.alpha_p, zero(T))
     fill!(ws.alpha_d, zero(T))
-    t_now = time()
-    batch_solver.batch_cnt.start_time[] = t_now
     fill!(batch_solver.batch_cnt.k, 0)
     batch_solver.batch_cnt.linear_solver_time[] = 0.0
     batch_solver.batch_cnt.eval_function_time[] = 0.0

--- a/src/batch/structure.jl
+++ b/src/batch/structure.jl
@@ -163,6 +163,8 @@ function UniformBatchMPCSolver(
     logger = options.logger
 
     batch_cnt = BatchCounters(batch_size)
+    batch_cnt.start_time[] = time()
+
     bcb = MadNLP.create_callback(
         UniformBatchCallback{T,VT,MT,VI},
         bnlp;
@@ -214,6 +216,8 @@ function UniformBatchMPCSolver(
 
     batch_del_w = fill!(MT(undef, 1, batch_size), zero(T))
     batch_del_c = fill!(MT(undef, 1, batch_size), zero(T))
+
+    batch_cnt.init_time[] = time() - batch_cnt.start_time[]
 
     return UniformBatchMPCSolver{T, MT, VT, VI, typeof(bnlp), typeof(bcb), typeof(batch_views), typeof(batch_kkts)}(
         batch_size,

--- a/src/batch/utils.jl
+++ b/src/batch/utils.jl
@@ -149,6 +149,7 @@ end
 struct BatchCounters
     k::Vector{Int}              # per-instance iteration count
     start_time::Base.RefValue{Float64}
+    init_time::Base.RefValue{Float64}
     total_time::Vector{Float64} # per-instance total solve time
     linear_solver_time::Base.RefValue{Float64}
     eval_function_time::Base.RefValue{Float64}
@@ -156,4 +157,4 @@ struct BatchCounters
     obj_grad_cnt::Base.RefValue{Int}
     con_cnt::Base.RefValue{Int}
 end
-BatchCounters(batch_size::Int) = BatchCounters(zeros(Int, batch_size), Ref(0.0), zeros(Float64, batch_size), Ref(0.0), Ref(0.0), Ref(0), Ref(0), Ref(0))
+BatchCounters(batch_size::Int) = BatchCounters(zeros(Int, batch_size), Ref(0.0), Ref(0.0), zeros(Float64, batch_size), Ref(0.0), Ref(0.0), Ref(0), Ref(0), Ref(0))

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -330,26 +330,26 @@ end
 
 # One iteration of Predictor-corrector method
 function mpc_step!(solver::MadNLP.AbstractMadNLPSolver)
-        # Factorize KKT system
-        factorize_system!(solver)
+    # Factorize KKT system
+    factorize_system!(solver)
 
-        # Prediction step
-        prediction_step!(solver)
+    # Prediction step
+    prediction_step!(solver)
 
-        # Mehrotra's Correction step
-        mehrotra_correction_direction!(solver)
+    # Mehrotra's Correction step
+    mehrotra_correction_direction!(solver)
 
-        # Gondzio's additional correction
-        gondzio_correction_direction!(solver)
+    # Gondzio's additional correction
+    gondzio_correction_direction!(solver)
 
-        # Update step size
-        update_step_size!(solver)
+    # Update step size
+    update_step_size!(solver)
 
-        # Apply step
-        apply_step!(solver)
+    # Apply step
+    apply_step!(solver)
 
-        # Evaluate model at new iterate
-        evaluate_model!(solver)
+    # Evaluate model at new iterate
+    evaluate_model!(solver)
 end
 
 function mpc!(solver::MadNLP.AbstractMadNLPSolver)
@@ -368,7 +368,6 @@ function solve!(
     kwargs...
 )
     nlp = solver.nlp
-    solver.cnt.start_time = time()
 
     if !isempty(kwargs)
         MadNLP.set_options!(solver.opt, kwargs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -210,9 +210,9 @@ end
     @test sol.solution[3] == 2.0
 end
 
-# @testset "MathOptInterface" begin
-#     include("MOI_wrapper.jl")
-# end
+@testset "MathOptInterface" begin
+    include("MOI_wrapper.jl")
+end
 
 include("batch/views.jl")
 include("batch/solver.jl")


### PR DESCRIPTION
Timing should include the symbolic factorization and the data initialization, otherwise it is highly misleading. 